### PR TITLE
Add filename support to API

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,6 +1,6 @@
 const compression = require('compression');
 const config = require('config');
-const cors = require('cors')
+const cors = require('cors');
 const express = require('express');
 const log = require('npmlog');
 const morgan = require('morgan');

--- a/app/src/components/docGen.js
+++ b/app/src/components/docGen.js
@@ -17,7 +17,7 @@ const docGen = {
       if (!body.template.contentEncodingType) {
         body.template.contentEncodingType = 'base64';
       }
-      await fs.promises.writeFile(tmpFile.name, Buffer.from(body.template.content, body.template.contentEncodingType));
+      await fs.promises.writeFile(tmpFile.name + '.docx', Buffer.from(body.template.content, body.template.contentEncodingType));
       log.debug(JSON.stringify(tmpFile));
 
       // If it's not an array of multiple data items, pass it into carbone as a singular object
@@ -26,7 +26,7 @@ const docGen = {
       // TODO: there's too much response stuff down here in a component layer, figure out how
       // better to have the asynchronous carbone render be blocking and wait for its response
       // up in the v1/docGen.js route layer, then handle response setting there.
-      carbone.render(tmpFile.name, data, (err, result) => {
+      carbone.render(tmpFile.name  + '.docx', data, (err, result) => {
         if (err) {
           const errTxt = `Error during Carbone generation. Error: ${err}`;
           log.error('generateDocument', errTxt);

--- a/app/src/components/docGen.js
+++ b/app/src/components/docGen.js
@@ -3,6 +3,7 @@ const carbone = require('carbone');
 const stream = require('stream');
 const tmp = require('tmp');
 const fs = require('fs');
+const utils = require('./utils');
 
 const docGen = {
   /** Generate a file using carbone to merge data into the supplied document template
@@ -17,7 +18,13 @@ const docGen = {
       if (!body.template.contentEncodingType) {
         body.template.contentEncodingType = 'base64';
       }
-      await fs.promises.writeFile(tmpFile.name + '.docx', Buffer.from(body.template.content, body.template.contentEncodingType));
+
+      // Put the actual extension from the supplied file onto the tmp filename
+      const inboundFileExtension = utils.getFileExtension(body.template.filename);
+      const tmpFilename = inboundFileExtension ? `${tmpFile.name}.${inboundFileExtension}` : tmpFile.name;
+      log.debug('Filename: ' + tmpFilename);
+
+      await fs.promises.writeFile(tmpFilename, Buffer.from(body.template.content, body.template.contentEncodingType));
       log.debug(JSON.stringify(tmpFile));
 
       // If it's not an array of multiple data items, pass it into carbone as a singular object
@@ -26,7 +33,7 @@ const docGen = {
       // TODO: there's too much response stuff down here in a component layer, figure out how
       // better to have the asynchronous carbone render be blocking and wait for its response
       // up in the v1/docGen.js route layer, then handle response setting there.
-      carbone.render(tmpFile.name  + '.docx', data, (err, result) => {
+      carbone.render(tmpFilename, data, (err, result) => {
         if (err) {
           const errTxt = `Error during Carbone generation. Error: ${err}`;
           log.error('generateDocument', errTxt);
@@ -37,7 +44,7 @@ const docGen = {
           readStream.end(result);
 
           response.status(201);
-          response.set('Content-Disposition', 'attachment; filename=test');
+          response.set('Content-Disposition', `attachment; filename=${body.template.filename}`);
           response.set('Content-Type', 'text/plain');
 
           readStream.pipe(response);

--- a/app/src/components/health.js
+++ b/app/src/components/health.js
@@ -1,6 +1,6 @@
 const log = require('npmlog');
 
-const checks = {
+const health = {
   /** TODO: Need this? Rethink Checks stuff...
    * Could try to connect to WIndward if we use that
    * Checks the connectivity of something...
@@ -20,8 +20,8 @@ const checks = {
    * @returns {object[]} An array of result objects
    */
   getStatus: () => Promise.all([
-    checks.getGeneratorStatus()
+    health.getGeneratorStatus()
   ])
 };
 
-module.exports = checks;
+module.exports = health;

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -4,7 +4,16 @@ const utils = {
    *  @param {integer} indent Number of spaces to indent
    *  @returns {string} A pretty printed string representation of `obj` with `indent` indentation
    */
-  prettyStringify: (obj, indent = 2) => JSON.stringify(obj, null, indent)
+  prettyStringify: (obj, indent = 2) => JSON.stringify(obj, null, indent),
+
+  /** From a string representing a filename, get the extension if there is one
+   *  @param {filename} string A filename in a string
+   *  @returns {string} The extension, ie ".docx", or undefined if there is none
+   */
+  getFileExtension: filename => {
+    const re = /(?:\.([^.]+))?$/;
+    return re.exec(filename)[1];
+  }
 };
 
 module.exports = utils;

--- a/app/src/components/validators.js
+++ b/app/src/components/validators.js
@@ -19,6 +19,11 @@ const models = {
   },
 
   template: {
+    /** @function filename is required */
+    filename: value => {
+      return validatorUtils.isString(value) && !validator.isEmpty(value, { ignore_whitespace: true });
+    },
+
     /** @function content is required */
     content: value => {
       return validatorUtils.isString(value) && !validator.isEmpty(value, { ignore_whitespace: true });
@@ -84,6 +89,11 @@ const customValidators = {
     if (validateTemplate) {
 
       let validateSize = true;
+      if (!models.template.filename(obj.template.filename)) {
+        errors.push({ value: obj.template.filename, message: 'Invalid value `template.filename`.' });
+        validateSize = false;
+      }
+
       if (!models.template.content(obj.template.content)) {
         errors.push({ value: obj.template.content, message: 'Invalid value `template.content`.' });
         validateSize = false;

--- a/app/src/routes/v1.js
+++ b/app/src/routes/v1.js
@@ -30,7 +30,7 @@ router.get('/api-spec.yaml', (_req, res) => {
   res.sendFile(path.join(__dirname, '../docs/v1.api-spec.yaml'));
 });
 
-/** health Router */
+/** Health Router */
 router.use('/health', keycloak.protect(), healthRouter);
 
 /** Doc Gen Router */

--- a/app/src/routes/v1.js
+++ b/app/src/routes/v1.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const keycloak = require('../components/keycloak');
 
-const checksRouter = require('./v1/checks');
+const healthRouter = require('./v1/health');
 const docGenRouter = require('./v1/docGen');
 
 const clientId = config.get('keycloak.clientId');
@@ -13,7 +13,7 @@ const clientId = config.get('keycloak.clientId');
 router.get('/', (_req, res) => {
   res.status(200).json({
     endpoints: [
-      '/checks',
+      '/health',
       '/docGen'
     ]
   });
@@ -30,8 +30,8 @@ router.get('/api-spec.yaml', (_req, res) => {
   res.sendFile(path.join(__dirname, '../docs/v1.api-spec.yaml'));
 });
 
-/** Checks Router */
-router.use('/checks', keycloak.protect(), checksRouter);
+/** health Router */
+router.use('/health', keycloak.protect(), healthRouter);
 
 /** Doc Gen Router */
 router.use('/docGen', keycloak.protect(`${clientId}:GENERATOR`), docGenRouter);

--- a/app/src/routes/v1/health.js
+++ b/app/src/routes/v1/health.js
@@ -1,9 +1,9 @@
-const checksRouter = require('express').Router();
+const healthRouter = require('express').Router();
 
-const checkComponent = require('../../components/checks');
+const checkComponent = require('../../components/health');
 
 /** Returns the status of correspondent APIs */
-checksRouter.get('/status', async (_req, res, next) => {
+healthRouter.get('/status', async (_req, res, next) => {
   const statuses = await checkComponent.getStatus();
 
   if (statuses instanceof Array) {
@@ -15,4 +15,4 @@ checksRouter.get('/status', async (_req, res, next) => {
   }
 });
 
-module.exports = checksRouter;
+module.exports = healthRouter;

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -25,3 +25,19 @@ describe('prettyStringify', () => {
   });
 });
 
+describe('getFileExtension', () => {
+  it('should return a the file extension when there is one', () => {
+    expect(utils.getFileExtension('abc_123.docx')).toEqual('docx');
+    expect(utils.getFileExtension('my file name here.docx')).toEqual('docx');
+    expect(utils.getFileExtension('file.name.with.dots.docx')).toEqual('docx');
+  });
+
+  it('should return undefined if no extension', () => {
+    expect(utils.getFileExtension('abc_123')).toEqual(undefined);
+    expect(utils.getFileExtension('')).toEqual(undefined);
+    expect(utils.getFileExtension('   ')).toEqual(undefined);
+    expect(utils.getFileExtension(null)).toEqual(undefined);
+    expect(utils.getFileExtension(undefined)).toEqual(undefined);
+  });
+});
+

--- a/app/tests/unit/components/validators/validators.customValidators.spec.js
+++ b/app/tests/unit/components/validators/validators.customValidators.spec.js
@@ -14,6 +14,7 @@ describe('customValidators.docGen', () => {
         y: 2
       }],
       template: {
+        filename: 'abc_123.docx',
         content: 'ZHNmc2Rmc2RmZHNmc2Rmc2Rmc2Rm',
         contentEncodingType: 'base64'
       }

--- a/app/tests/unit/components/validators/validators.models.spec.js
+++ b/app/tests/unit/components/validators/validators.models.spec.js
@@ -78,8 +78,20 @@ describe('models.docGen.template', () => {
 
 describe('models.template', () => {
 
-  it('should return false for no filename', async () => {
+  it('should return false for blank filename', async () => {
     const filename = '';
+    const result = await models.template.filename(filename);
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for null filename', async () => {
+    const filename = null;
+    const result = await models.template.filename(filename);
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false for undefined filename', async () => {
+    const filename = undefined;
     const result = await models.template.filename(filename);
     expect(result).toBeFalsy();
   });

--- a/app/tests/unit/components/validators/validators.models.spec.js
+++ b/app/tests/unit/components/validators/validators.models.spec.js
@@ -57,8 +57,8 @@ describe('models.docGen.contexts', () => {
 describe('models.docGen.template', () => {
 
   it('should return true for a valid template object', () => {
-    const value = [{ content: 'x', encoding: 'y' }];
-    const result = models.docGen.contexts(value);
+    const value = { filename: 'abc_123.docx', content: 'x', encoding: 'y' };
+    const result = models.docGen.template(value);
     expect(result).toBeTruthy();
   });
 
@@ -77,6 +77,12 @@ describe('models.docGen.template', () => {
 
 
 describe('models.template', () => {
+
+  it('should return false for no filename', async () => {
+    const filename = '';
+    const result = await models.template.filename(filename);
+    expect(result).toBeFalsy();
+  });
 
   it('should return true for file size equal to limit', async () => {
     const content = smallFile.content;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Add the filename request parameter support, use the extension of the file in the temp file Carbone processes.
Filename is now a **mandatory field.**
Also fix the health endpoint to be the correct route name.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
