### PR TITLE
Revert "Restrict k8s API access to only deployers"

### DIFF
--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -10,13 +10,12 @@ objects:
   - apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
     kind: NetworkSecurityPolicy
     metadata:
-      name: "${APP_NAME}-app-${JOB_NAME}-sa-deployer-to-k8s-api-${NAMESPACE}"
+      name: "${APP_NAME}-app-${JOB_NAME}-pods-to-k8s-api-${NAMESPACE}"
     spec:
       description: |
-        Allow deployer service account to talk to the internal K8S api
+        Allow pods to talk to the internal K8S api
       source:
         - - $namespace=${NAMESPACE}
-          - "@app:k8s:serviceaccountname=deployer"
       destination:
         - - int:network=internal-cluster-api-endpoint
   - apiVersion: v1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This reverts commit 9420911d10b56c6b16d7baac11368742c767bce6 and rolls back the following PR: https://github.com/bcgov/common-document-generation-service/pull/13
<!-- Why is this change required? What problem does it solve? -->
We have discovered that service account selectors to restrict the k8s API access do not work as documented/intended at this time. This rollback is needed to ensure that the service remains operational.
<!-- If it fixes an open issue, please link to the issue here. -->
[[SHOWCASE-480]](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-480)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
