### PR TITLE
Restrict k8s access to deployer service account

### DIFF
--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -10,19 +10,18 @@ objects:
   - apiVersion: secops.pathfinder.gov.bc.ca/v1alpha1
     kind: NetworkSecurityPolicy
     metadata:
-      name: "${APP_NAME}-app-${JOB_NAME}-pods-to-k8s-api-${NAMESPACE}"
+      name: "${APP_NAME}-${JOB_NAME}-sa-deployer-to-k8s-api-${NAMESPACE}"
     spec:
       description: |
-        Allow pods to talk to the internal K8S api
+        Allow deployer pods to talk to the internal K8S api
       source:
-        - - $namespace=${NAMESPACE}
+        - - "$namespace=${NAMESPACE}"
+          - "@app:k8s:serviceaccountname=deployer"
       destination:
         - - int:network=internal-cluster-api-endpoint
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
-      annotations:
-        openshift.io/generated-by: OpenShiftNewApp
       name: "${APP_NAME}-app-${JOB_NAME}"
     spec:
       replicas: 2
@@ -38,8 +37,6 @@ objects:
           timeoutSeconds: 600
       template:
         metadata:
-          annotations:
-            openshift.io/generated-by: OpenShiftNewApp
           labels:
             app: "${APP_NAME}-${JOB_NAME}"
             deploymentconfig: "${APP_NAME}-app-${JOB_NAME}"
@@ -112,8 +109,6 @@ objects:
   - apiVersion: v1
     kind: Service
     metadata:
-      annotations:
-        openshift.io/generated-by: OpenShiftNewApp
       name: "${APP_NAME}-app-${JOB_NAME}"
     spec:
       ports:
@@ -128,8 +123,6 @@ objects:
   - apiVersion: v1
     kind: Route
     metadata:
-      annotations:
-        openshift.io/host.generated: "true"
       name: "${APP_NAME}-app-${JOB_NAME}"
     spec:
       host: "${HOST_ROUTE}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This change re-applies https://github.com/bcgov/common-document-generation-service/pull/13 as the platform now properly parses and handles serviceaccount selectors.
* Remove unnecessary openshift annotations
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
