### PR TITLE
Pretty print Timestamp

### DIFF
--- a/app/src/middleware/apiTracker.js
+++ b/app/src/middleware/apiTracker.js
@@ -21,13 +21,13 @@ const trackerUrls = [docGenUrl];
 
 // add in any token (custom or morgan built-in) we want to the format, then morgan can parse out later
 // status and response-time is a built-in morgan token
-const apiTrackerFormat = ':operation :azp :timestamp :contextKeyCount :contentFileType :contentEncodingType :contentSize :outputFileType :res[content-length] :status :response-time';
+const apiTrackerFormat = ':op :azp :ts :contextKeyCount :contentFileType :contentEncodingType :contentSize :outputFileType :res[content-length] :status :response-time';
 
 const apiTracker = async (req, res, next) => {
 
   if (trackerUrls.includes(req.url)) {
-    req._timestamp = moment.utc().valueOf();
-    req._operation = req.url === docGenUrl ? 'DOCGEN' : 'Unknown';
+    req._ts = moment.utc().valueOf();
+    req._op = req.url === docGenUrl ? 'DOCGEN' : 'Unknown';
 
     /*
     When/If we need to parse data out of the response, we would do it here...
@@ -51,23 +51,23 @@ const apiTracker = async (req, res, next) => {
   next();
 };
 
-const initializeApiTracker = (app) => {
+const initializeApiTracker = app => {
 
   // register token parser functions.
   // this one would depend on authorizedParty middleware being loaded
-  morgan.token('azp', (req) => {
+  morgan.token('azp', req => {
     return req.authorizedParty ? req.authorizedParty : '-';
   });
 
-  morgan.token('operation', (req) => {
-    return req._operation ? req._operation : '-';
+  morgan.token('op', req => {
+    return req._op ? req._op : '-';
   });
 
-  morgan.token('timestamp', (req) => {
-    return req._timestamp ? req._timestamp : '-';
+  morgan.token('ts', req => {
+    return req._ts ? req._ts : '0';
   });
 
-  morgan.token('contextKeyCount', (req) => {
+  morgan.token('contextKeyCount', req => {
     function countKeys(source) {
       if (!source) return 0;
       let result = 0;
@@ -97,7 +97,7 @@ const initializeApiTracker = (app) => {
     }
   });
 
-  morgan.token('contentFileType', (req) => {
+  morgan.token('contentFileType', req => {
     try {
       return req.body.template.contentFileType;
     } catch (e) {
@@ -105,7 +105,7 @@ const initializeApiTracker = (app) => {
     }
   });
 
-  morgan.token('contentEncodingType', (req) => {
+  morgan.token('contentEncodingType', req => {
     try {
       return req.body.template.contentEncodingType;
     } catch (e) {
@@ -113,7 +113,7 @@ const initializeApiTracker = (app) => {
     }
   });
 
-  morgan.token('contentSize', (req) => {
+  morgan.token('contentSize', req => {
     try {
       const buf = Buffer.from(req.body.template.content, req.body.template.contentEncodingType);
       return buf.length;
@@ -122,7 +122,7 @@ const initializeApiTracker = (app) => {
     }
   });
 
-  morgan.token('outputFileType', (req) => {
+  morgan.token('outputFileType', req => {
     try {
       return req.body.template.outputFileType;
     } catch (e) {
@@ -137,11 +137,11 @@ const initializeApiTracker = (app) => {
     },
     stream: {
       write: (s) => {
-        if (s && s.trim().length > 0) {
+        if (s && s.trim().length) {
           const parts = s.trim().split(' ');
           const ts = Number.parseInt(parts[2]);
-          // format this to match Kibana pretty format (almost - utc + timezone)...
-          const timestamp = moment.utc(ts).format('MMMM Do YYYY, HH:mm:ss.SSSZZ');
+          // format this to match Kibana 2020-01-06T22:55:29.767054+00:00...
+          const timestamp = moment.utc(ts).format('YYYY-MM-DDTHH:mm:ss.SSSSSSZ');
           const o = {
             clogs: {
               type: 'CDOGS_API_TRACKER',


### PR DESCRIPTION
Make our timestamp pretty print field look more like Kibana's @timestamp field.
Touched up some stuff to match style guide.

<!-- Provide a general summary of your changes in the Title above -->
# Description
The body of Kibana data has an @timestamp field, make our pretty print timestamp field look the same.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->