### PR TITLE
Adjust morgan token for outputFileType

### DIFF
--- a/app/src/middleware/apiTracker.js
+++ b/app/src/middleware/apiTracker.js
@@ -159,7 +159,8 @@ const initializeApiTracker = app => {
 
   morgan.token('outputFileType', req => {
     try {
-      return req.body.template.outputFileType;
+      // if output file type not specified, then we use the content (input) file type.
+      return req.body.template.outputFileType ? req.body.template.outputFileType : req.body.template.contentFileType;
     } catch (e) {
       return '-';
     }


### PR DESCRIPTION
Adjust morgan token for outputFileType - follow logic of docGen processor.
Was returning "-" when no output type specified, but the output is actually the same as input type in that case.  Need to return something better than "-" for the dashboard.

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
