### PR TITLE
Ensure pr builds use less PVC space than master builds

### DIFF
--- a/openshift/commonPipeline.groovy
+++ b/openshift/commonPipeline.groovy
@@ -77,17 +77,29 @@ def runStageDeploy(String stageEnv, String projectEnv, String hostEnv, String pa
         openshift.tag("${TOOLS_PROJECT}/${REPO_NAME}-app:${JOB_NAME}", "${REPO_NAME}-app:${JOB_NAME}")
 
         echo "Processing DeploymentConfig ${REPO_NAME}-app-${JOB_NAME}..."
-        def dcAppTemplate = openshift.process('-f',
-          'openshift/app.dc.yaml',
-          "REPO_NAME=${REPO_NAME}",
-          "JOB_NAME=${JOB_NAME}",
-          "NAMESPACE=${projectEnv}",
-          "APP_NAME=${APP_NAME}",
-          "HOST_ROUTE=${hostEnv}",
-          'FILE_CACHE_VOLUME_CAPACITY=21M',
-          'FILE_CACHE_VOLUME_CAPACITY_BYTES=21MB',
-          'FILE_CACHE_MAX_FILE_SIZE=10MB'
-        )
+        def dcAppTemplate
+        if(hostEnv.contains('pr-')) {
+          dcAppTemplate = openshift.process('-f',
+            'openshift/app.dc.yaml',
+            "REPO_NAME=${REPO_NAME}",
+            "JOB_NAME=${JOB_NAME}",
+            "NAMESPACE=${projectEnv}",
+            "APP_NAME=${APP_NAME}",
+            "HOST_ROUTE=${hostEnv}",
+            'FILE_CACHE_VOLUME_CAPACITY=21M',
+            'FILE_CACHE_VOLUME_CAPACITY_BYTES=21MB',
+            'FILE_CACHE_MAX_FILE_SIZE=10MB'
+          )
+        } else {
+          dcAppTemplate = openshift.process('-f',
+            'openshift/app.dc.yaml',
+            "REPO_NAME=${REPO_NAME}",
+            "JOB_NAME=${JOB_NAME}",
+            "NAMESPACE=${projectEnv}",
+            "APP_NAME=${APP_NAME}",
+            "HOST_ROUTE=${hostEnv}"
+          )
+        }
 
         echo "Applying ${REPO_NAME}-app-${JOB_NAME} Deployment..."
         def dcApp = openshift.apply(dcAppTemplate).narrow('dc')


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR fixes the following pipeline error:
`The PersistentVolumeClaim "file-cache-data-master" is invalid: spec.resources.requests.storage: Forbidden: field can not be less than previous value`
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
