### PR TITLE
Add Dockerized CDOGS Support

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,16 @@
+---
+name: Docker Image CI
+on:
+  - push
+  - pull_request
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag common-document-generation-service:$(date +%s)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/b360d0b4c9ad56149499/maintainability)](https://codeclimate.com/github/bcgov/common-document-generation-service/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/b360d0b4c9ad56149499/test_coverage)](https://codeclimate.com/github/bcgov/common-document-generation-service/test_coverage)
 
+[![version](https://img.shields.io/docker/v/bcgovimages/common-document-generation-service.svg?sort=semver)](https://hub.docker.com/r/bcgovimages/common-document-generation-service)
+[![pulls](https://img.shields.io/docker/pulls/bcgovimages/common-document-generation-service.svg)](https://hub.docker.com/r/bcgovimages/common-document-generation-service)
+[![size](https://img.shields.io/docker/image-size/bcgovimages/common-document-generation-service.svg)](https://hub.docker.com/r/bcgovimages/common-document-generation-service)
+
 CDOGS - A common hosted service (API) for generating documents from templates, data documents, and assets
 
 To learn more about the **Common Services** available visit the [Common Services Showcase](https://bcgov.github.io/common-service-showcase/) page.
@@ -11,7 +15,11 @@ To learn more about the **Common Services** available visit the [Common Services
 ## Directory Structure
 
     .github/                   - PR and Issue templates
-    app/                       - Node.js web API
+    app/                       - Application Root
+    ├── docker/                - Auxillary support scripts for LibreOffice Python wrapper
+    ├── src/                   - Node.js backend web application
+    ├── tests/                 - Node.js backend web application tests
+    └── Dockerfile             - Docker image specification
     openshift/                 - OpenShift-deployment specific files
     CODE-OF-CONDUCT.md         - Code of Conduct
     COMPLIANCE.yaml            - BCGov PIA/STRA compliance status
@@ -24,7 +32,8 @@ To learn more about the **Common Services** available visit the [Common Services
 
 * [Application Readme](app/README.md)
 * [Openshift Readme](openshift/README.md)
-* [Showcase Team Roadmap](https://github.com/bcgov/nr-get-token/wiki/Product-Roadmap)
+* [Devops Tools Setup](https://github.com/bcgov/nr-showcase-devops-tools)
+* [Product Roadmap](https://github.com/bcgov/nr-get-token/wiki/Product-Roadmap)
 
 ## Getting Help or Reporting an Issue
 

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,29 @@
+.DS_Store
+.gradle
+.nyc_output
+.scannerwork
+build
+coverage
+dist
+node_modules
+
+# local env files
+local.*
+local-*.*
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.iml
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw*

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.io/bcgovimages/alpine-node-libreoffice:v1.0.3
+
+ARG APP_ROOT=/opt/app-root/src
+ENV NO_UPDATE_NOTIFIER=true \
+    APP_PORT=3000
+WORKDIR ${APP_ROOT}
+
+COPY . .
+RUN npm ci
+
+EXPOSE ${APP_PORT}
+CMD ["npm", "run", "start"]

--- a/app/USAGE.md
+++ b/app/USAGE.md
@@ -118,10 +118,10 @@ Context
 ``` json
 {
   "cars" : [
-    {"brand" : "Lumeneo"},
-    {"brand" : "Tesla"  },
-    {"brand" : "Toyota" },
-    {"brand" : "Ford" }
+    { "brand": "Lumeneo" },
+    { "brand": "Tesla" },
+    { "brand": "Toyota" },
+    { "brand": "Ford" }
   ]
 }
 ```

--- a/app/USAGE.md
+++ b/app/USAGE.md
@@ -1,0 +1,189 @@
+# Application Details
+
+The application is a node server which serves the Common Document Generation Service API. It uses the following dependencies from NPM:
+
+Authentication & Password Management
+
+- [keycloak-connect](https://www.npmjs.com/package/keycloak-connect) - Node adapter for Keycloak OIDC
+
+Networking
+
+- [api-problem](https://www.npmjs.com/package/api-problem) - RFC 7807 problem details
+- [express](https://www.npmjs.com/package/express) - Server middleware
+
+Configuration
+
+- [config](https://www.npmjs.com/package/config) - organizes hierarchical configurations for your app deployments; handles environment variables, command line parameters and external sources.
+
+Logging
+
+- [morgan](https://www.npmjs.com/package/morgan) - HTTP request logger
+- [npmlog](https://www.npmjs.com/package/npmlog) - General log framework
+
+Docker Image
+
+- [bcgovimages/alpine-node-libreoffice](https://hub.docker.com/r/bcgovimages/alpine-node-libreoffice) - a base image with Node.js LTS and LibreOffice™ installed.  LibreOffice™ is used for the file conversions.
+
+## Design and Usage
+
+The `/template/render` endpoint request body is composed of 3 main parts.
+
+1. The set of **data**, an object containing the set of replacement variables to merge into the template.  This can be an array of objects.
+2. **options**, an object to override default behaviours.  Callers should be setting: convertTo = (output file type), reportName = (output file name), and overwrite=true.
+3. The document **template**, currently only accepts this as a base64 encoding.
+
+``` json
+{
+  "data": {
+    "firstName": "Jane",
+    "lastName": "Smith",
+    "title": "CEO"
+  },
+  "options": {
+    "convertTo": "pdf",
+    "reportName": "{d.firstName}-{d.lastName}.docx",
+    "overwrite": "true"
+  },
+  "template": {
+    "fileType": "docx",
+    "encodingType": "base64",
+    "content": "base64 encoded content..."
+  }
+}
+```
+
+The functionality of this endpoint is relatively simple, being that it functions mostly as a pass-through to the Carbone library to do the generation logic.  Templates and rendered reports are written to disk and can fetched or deleted through the api.  Refer to the [carbone-copy-api](https://github.com/bcgov/common-services-team-library/tree/master/npm/carbone-copy-api/docs) documentation.
+
+The templating engine is XML-agnostic. It means the template engine works on any valid XML-based documents, not only XML-documents created by Microsoft Office™, LibreOffice™ or OpenOffice™.
+
+### Concepts
+
+In order to provide template substitution of variables into the supplied document, we have to pass in a **data*-  object.  The data object is a free-form JSON object which consists of key-value pairs. The purpose is to provide a key-value mapping between an inline variable in the template document and the intended merged document output after the values are replaced.  **data*- can be an array of JSON objects.
+
+Carbone can behave as a glorified string-replacement engine, or more complex conditional or iterative logic can be built into the template variables. See below sections for documentation.
+In the event the Context object has extra variables that are not used in the template document, nothing happens. You can expect to see blanks where no value was substituted.
+
+## Templating
+
+We currently leverage the Carbone JS library for variable replacement into document templates. Carbone finds all markers `{}` in your document (xlsx, odt, docx, ...) and replaces these markers by Context variables representing the data. According to the syntax of your markers, you can make a number of complex operations if desired, further documentation below describes this more.
+
+The convention of having "d." before variable names from the Context (d for "data") is used by the templating engine.
+
+As repetitions (loops of arrays) are a core component of the templating engine, the data object in the request body can be an array, or contain arrays.
+
+### [Variable Substitution](https://carbone.io/documentation.html#substitutions)
+
+The Carbone templating engine allows variables to be in-line displayed through the use of double curly braces. Suppose you wanted a variable `foo` to be displayed. You can do so by adding the following into a document template:
+
+``` sh
+{{d.foo}}
+```
+
+Nested objects in the Context are supported. You can lookup properties that have dots in them just like you would in Javascript. Suppose for example you have the following context object and template string:
+
+Context
+
+``` json
+{
+  "something": {
+    "greeting": "Hello",
+    "target": "World"
+  },
+  "someone": "user"
+}
+```
+
+Template document
+
+``` sh
+"My template is: {{d.something.greeting}} {{d.someone}} content {{d.something.target }}"
+```
+
+You can expect the template engine to yield the following:
+
+``` sh
+"My template is: Hello user content World"
+```
+
+### [Repetitions](https://carbone.io/documentation.html#repetitions)
+
+Carbone can repeat a section (rows, title, pages...) of the document.
+
+We don't need to describe where the repetition starts and ends, we just need to design a "repetition example" in the template using the reserved key word i and i+1. Carbone will find automatically the pattern to repeat using the first row (i) as an example. The second row (i+1) is removed before rendering the result.
+
+For the simplest example, suppose you have the following context object and template document:
+
+Context
+
+``` json
+{
+  "cars" : [
+    {"brand" : "Lumeneo"},
+    {"brand" : "Tesla"  },
+    {"brand" : "Toyota" },
+    {"brand" : "Ford" }
+  ]
+}
+```
+
+Template document
+
+| Cars                  |
+| --------------------- |
+| {d.cars[i].brand}     |
+| {d.cars[i+1].brand}   |
+
+You can expect the template engine to yield the following:
+
+| Cars                  |
+| --------------------- |
+| Lumeneo    |
+| Tesla   |
+| Toyota   |
+| Ford   |
+
+See the Carbone Repetition documentation for the much more complex examples
+
+### File Name
+
+The `options` object in the request body contains an optional `reportName` field. This field will serve as the requested file name for the resultant merged document.
+If not supplied, a random UUID (such as 6a2f41a3-c54c-fce8-32d2-0324e1c32e22) will serve as the placeholder.
+
+You can template the output file name in the same manner as the contents.
+
+An example request is shown below:
+
+``` json
+{
+  "data": [
+    {
+      "office": {
+        "id": "Dx1997",
+        "location": "Hello",
+        "phone": "World"
+      },
+      "contact": "Bob"
+    }],
+  "options" : {
+    "convertTo": "pdf",
+    "reportName": "office_contact_{d.office.id}.docx",
+  },
+  "template": {
+    "content": "<encoded file here>",
+    "encodingType": "base64",
+    "fileType": "docx"
+  }
+}
+```
+
+This will yield a resultant file in the response named
+`office_contact_Dx1997.pdf`
+
+#### Further templating functionality
+
+The templating engine in Carbone has a lot of power, refer to the Carbone documentation
+
+- <https://carbone.io/documentation.html#substitutions>
+- <https://carbone.io/documentation.html#repetitions>
+- <https://carbone.io/documentation.html#formatters>
+- <https://carbone.io/documentation.html#translations>

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -5,7 +5,7 @@
   },
   "server": {
     "bodyLimit": "100mb",
-    "logLevel": "debug",
+    "logLevel": "info",
     "morganFormat": "dev",
     "port": "3000"
   },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-document-generation-service",
-  "version": "2.0.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-document-generation-service",
-  "version": "2.0.0",
+  "version": "2.3.0",
   "description": "CDOGS - A common document generation API",
   "private": true,
   "scripts": {

--- a/app/src/components/carboneCopyApi.js
+++ b/app/src/components/carboneCopyApi.js
@@ -89,6 +89,7 @@ const carboneCopyApi = {
 
     try {
       formatters = telejson.parse(req.body.formatters);
+      // TODO: Consider adding warning message to log
       // eslint-disable-next-line no-empty
     } catch (e) {
     }

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -28,6 +28,8 @@ In order to prepare an environment, you will need to ensure that all of the foll
 export NAMESPACE=<YOURNAMESPACE>
 
 oc create -n $NAMESPACE configmap cdogs-keycloak-config \
+  --from-literal=KC_ENABLED=true \
+  --from-literal=KC_PUBLICKEY=<MIIBIjANB...> \
   --from-literal=KC_REALM=jbd6rnxw \
   --from-literal=KC_SERVERURL=https://dev.oidc.gov.bc.ca/auth
 ```
@@ -36,7 +38,6 @@ oc create -n $NAMESPACE configmap cdogs-keycloak-config \
 
 ```sh
 oc create -n $NAMESPACE configmap cdogs-server-config \
-  --from-literal=SERVER_ATTACHMENTLIMIT=20mb \
   --from-literal=SERVER_BODYLIMIT=100mb \
   --from-literal=SERVER_LOGLEVEL=info \
   --from-literal=SERVER_MORGANFORMAT=combined \
@@ -54,13 +55,6 @@ oc create -n $NAMESPACE secret generic cdogs-keycloak-secret \
   --type=kubernetes.io/basic-auth \
   --from-literal=username=<username> \
   --from-literal=password=<password>
-```
-
-```sh
-oc create -n $NAMESPACE secret generic cdogs-common-service-secret \
-  --type=kubernetes.io/basic-auth \
-  --from-literal=username=<cdogs common service client id> \
-  --from-literal=password=<cdogs common service client password>
 ```
 
 ## Build Config & Deployment

--- a/openshift/app.bc.yaml
+++ b/openshift/app.bc.yaml
@@ -41,16 +41,9 @@ objects:
           ref: "${SOURCE_REPO_REF}"
           uri: "${SOURCE_REPO_URL}"
         type: Git
-        dockerfile: |-
-          FROM BuildConfig
-          ENV NO_UPDATE_NOTIFIER=true
-          WORKDIR /opt/app-root/src
-          COPY . .
-          RUN npm ci
-          EXPOSE 3000
-          CMD ["npm", "run", "start"]
       strategy:
         dockerStrategy:
+          dockerfilePath: Dockerfile
           env:
             - name: BUILD_LOGLEVEL
               value: "2"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on emitting CDOGS as a standalone docker image that can be consumed by 3rd party developers in addition to supporting the hosted instance. Also includes comprehensive documentation update in order to cleanly present to users what they need to know to get started and working with CDOGS.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2170](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2170)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This PR completes the lifecycle transition of docker image `doc-gen-api` to `common-document-generation-service`.