### PR TITLE
Determine 422s

### DIFF
--- a/app/src/components/carboneCopyApi.js
+++ b/app/src/components/carboneCopyApi.js
@@ -112,12 +112,13 @@ const carboneCopyApi = {
 
       return res.send(output.report);
     } else {
+      const errOutput = { detail: output.errorMsg };
       if (output.errorType === 422) {
         // Format template syntax errors to be the same as our validation errors
-        return new Problem(output.errorType, { detail: 'Error in supplied template', errors: [{ message: output.errorMsg }] }).send(res);
-      } else {
-        return new Problem(output.errorType, { detail: output.errorMsg }).send(res);
+        errOutput.detail = 'Error in supplied template';
+        errOutput.errors = [{ message: output.errorMsg }];
       }
+      return new Problem(output.errorType, errOutput).send(res);
     }
   }
 };

--- a/app/src/components/carboneCopyApi.js
+++ b/app/src/components/carboneCopyApi.js
@@ -112,7 +112,12 @@ const carboneCopyApi = {
 
       return res.send(output.report);
     } else {
-      return new Problem(output.errorType, { detail: output.errorMsg }).send(res);
+      if (output.errorType === 422) {
+        // Format template syntax errors to be the same as our validation errors
+        return new Problem(output.errorType, { detail: 'Error in supplied template', errors: [{ message: output.errorMsg }] }).send(res);
+      } else {
+        return new Problem(output.errorType, { detail: output.errorMsg }).send(res);
+      }
     }
   }
 };

--- a/app/src/components/carboneRender.js
+++ b/app/src/components/carboneRender.js
@@ -3,6 +3,7 @@ const config = require('config');
 const fs = require('fs-extra');
 const log = require('npmlog');
 const path = require('path');
+const utils = require('./utils');
 const { v4: uuidv4 } = require('uuid');
 
 // Initialize carbone formatters and add a marker to indicate defaults...
@@ -89,7 +90,7 @@ async function render(template, data = {}, options = {}, formatters = {}) {
     result.reportName = renderResult.reportName;
     result.success = true;
   } catch (e) {
-    result.errorType = 500;
+    result.errorType = utils.determineCarboneErrorCode(e.message);
     result.errorMsg = `Could not render template. ${e.message}`;
   }
   resetFormatters(reset);

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -1,6 +1,27 @@
 const { v4: uuidv4 } = require('uuid');
+const log = require('npmlog');
 
 module.exports = {
+
+  /**
+  * @function determineCarboneErrorCode
+  * We want to return 422s if the template has a user error in it's construction.
+  * Carbone doesn't throw specific errors in this case, so we'll do a best-effort of
+  * determining if it should be a 422 or not (keep doing a 500 in any other case)
+  * @param {err} String The thrown exception from Carbone
+  * @returns {integer} The output filename for the response
+  */
+  determineCarboneErrorCode: err => {
+    try {
+      if (err && /formatter .*does not exist|missing at least one|cannot access parent object in/gmi.test(err))
+        return 422;
+    } catch (e) {
+      // Safety here, this method should never cause any unhandled exception since it's an error code determiner
+      log.warn(`Error while determining carbone error code: ${e}`);
+    }
+    return 500;
+  },
+
   /**
    * @function determineOutputReportName
    * For the DocGen component, determine what the outputted (response) filename should be based

--- a/app/src/components/utils.js
+++ b/app/src/components/utils.js
@@ -4,13 +4,13 @@ const log = require('npmlog');
 module.exports = {
 
   /**
-  * @function determineCarboneErrorCode
-  * We want to return 422s if the template has a user error in it's construction.
-  * Carbone doesn't throw specific errors in this case, so we'll do a best-effort of
-  * determining if it should be a 422 or not (keep doing a 500 in any other case)
-  * @param {err} String The thrown exception from Carbone
-  * @returns {integer} The output filename for the response
-  */
+   * @function determineCarboneErrorCode
+   * We want to return 422s if the template has a user error in it's construction.
+   * Carbone doesn't throw specific errors in this case, so we'll do a best-effort of
+   * determining if it should be a 422 or not (keep doing a 500 in any other case)
+   * @param {err} String The thrown exception from Carbone
+   * @returns {integer} The output filename for the response
+   */
   determineCarboneErrorCode: err => {
     try {
       if (err && /formatter .*does not exist|missing at least one|cannot access parent object in/gmi.test(err))

--- a/app/tests/unit/components/utils.spec.js
+++ b/app/tests/unit/components/utils.spec.js
@@ -3,6 +3,27 @@ const utils = require('../../../src/components/utils');
 
 logHelper();
 
+describe('determineCarboneErrorCode', () => {
+  it('should return a 422 for expected error strings', () => {
+    expect(utils.determineCarboneErrorCode('Formatter \\"convDe\\" does not exist. Do you mean \\"convDate\\"?"')).toEqual(422);
+    expect(utils.determineCarboneErrorCode('Error: formatter "ifEkual" DOES NOT exist. Do you mean "ifEqual"?')).toEqual(422);
+    expect(utils.determineCarboneErrorCode('Error: Cannot access parent object in "d.site...name" (too high)')).toEqual(422);
+    expect(utils.determineCarboneErrorCode('cannot access parent object in whatever')).toEqual(422);
+    expect(utils.determineCarboneErrorCode('Missing at least one showBegin or hideBegin')).toEqual(422);
+    expect(utils.determineCarboneErrorCode('missing at least one showEnd or hideEnd')).toEqual(422);
+  });
+
+  it('should return a 500 for anything else', () => {
+    expect(utils.determineCarboneErrorCode('XML not valid')).toEqual(500);
+    expect(utils.determineCarboneErrorCode('')).toEqual(500);
+    expect(utils.determineCarboneErrorCode('   ')).toEqual(500);
+    expect(utils.determineCarboneErrorCode(null)).toEqual(500);
+    expect(utils.determineCarboneErrorCode(undefined)).toEqual(500);
+    expect(utils.determineCarboneErrorCode([])).toEqual(500);
+    expect(utils.determineCarboneErrorCode({})).toEqual(500);
+  });
+});
+
 describe('prettyStringify', () => {
   const obj = {
     foo: 'bar'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2094

For errors in template render that are due to supplied template syntax problems, give the user back a 422 with the message rather than a 500.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Carbone just returns a string error so it could fail on either a template problem, or an actual internal server error, so just have to do a best-effort error string match.
