### PR TITLE
Feat/ods support

### DIFF
--- a/app/src/components/carboneRender.js
+++ b/app/src/components/carboneRender.js
@@ -15,12 +15,12 @@ const fileTypes = Object.freeze({
   csv: ['csv', 'doc', 'docx', 'html', 'odt', 'pdf', 'rtf', 'txt'],
   docx: ['doc', 'docx', 'html', 'odt', 'pdf', 'rtf', 'txt'],
   html: ['html', 'odt', 'pdf', 'rtf', 'txt'],
+  ods: ['csv', 'ods', 'pdf', 'txt', 'xls', 'xlsx'],
   odt: ['doc', 'docx', 'html', 'odt', 'pdf', 'rtf', 'txt'],
-  pptx: ['odt', 'pdf', 'pptx', 'ppt'],
+  pptx: ['odt', 'pdf', 'ppt', 'pptx'],
   rtf: ['docx', 'pdf'],
   txt: ['doc', 'docx', 'html', 'odt', 'pdf', 'rtf', 'txt'],
-  xlsx: ['ods', 'pdf', 'rtf', 'txt', 'csv', 'xls', 'xlsx'],
-  ods: ['ods', 'xlsx', 'xls', 'csv', 'pdf', 'txt']
+  xlsx: ['csv', 'ods', 'pdf', 'rtf', 'txt', 'xls', 'xlsx']
 });
 
 function addFormatters(formatters) {


### PR DESCRIPTION
Adds support for ods template documents.

Updates xlsx output option from odt -> ods

Taken from: 
https://carbone.io/documentation.html#supported-files-and-features-list