### PR TITLE
Fix NPM Cache directory permission and PID Signalling bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN wget https://www2.gov.bc.ca/assets/gov/british-columbians-our-governments/se
     rm -rf ./BcSansFont_Print && \
     fc-cache -f
 
-# NPM Permission Fix (already present in base image)
+# NPM Permission Fix
+RUN mkdir -p /.npm
+RUN chown -R 1001:0 /.npm
 
 # Install Application
 COPY app ${APP_ROOT}
@@ -27,4 +29,4 @@ USER 1001
 RUN npm ci --omit=dev
 
 EXPOSE ${APP_PORT}
-CMD ["npm", "run", "start"]
+CMD ["node", "./bin/www"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -18,7 +18,9 @@ RUN wget https://www2.gov.bc.ca/assets/gov/british-columbians-our-governments/se
     rm -rf ./BcSansFont_Print && \
     fc-cache -f
 
-# NPM Permission Fix (already present in base image)
+# NPM Permission Fix
+RUN mkdir -p /.npm
+RUN chown -R 1001:0 /.npm
 
 # Install Application
 COPY . .
@@ -27,4 +29,4 @@ USER 1001
 RUN npm ci --omit=dev
 
 EXPOSE ${APP_PORT}
-CMD ["npm", "run", "start"]
+CMD ["node", "./bin/www"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
NPM appears to not propagate the SIGTERM signal to the child node app
on alpine. This is fixed by unwrapping the call and starting the app
directly instead. NPM cache directory permission issues have appeared
again for some external reason, so we need to mitigate by explicitly
forcing a permission update on the cache directory to be owned by a
non-root user.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
