### PR TITLE
Optimize and remove unnecessary I/O operations from cache cleaning job

### DIFF
--- a/charts/cdogs/Chart.yaml
+++ b/charts/cdogs/Chart.yaml
@@ -3,7 +3,7 @@ name: common-document-generation-service
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 kubeVersion: ">= 1.13.0"
 description: A microservice for merging JSON data into xml-based templates (powered by Carbone.io)
 # A chart can be either an 'application' or a 'library' chart.

--- a/charts/cdogs/README.md
+++ b/charts/cdogs/README.md
@@ -1,6 +1,6 @@
 # common-document-generation-service
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 A microservice for merging JSON data into xml-based templates (powered by Carbone.io)
 

--- a/charts/cdogs/templates/cronjob.yaml
+++ b/charts/cdogs/templates/cronjob.yaml
@@ -14,7 +14,7 @@ spec:
       labels: {{ include "cdogs.labels" . | nindent 8 }}
     spec:
       backoffLimit: 6
-      activeDeadlineSeconds: 300
+      activeDeadlineSeconds: 600
       parallelism: 1
       completions: 1
       template:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR focuses on removing unnecessary I/O from the cache cleaning cron job, instead only calculating what must be done once. We also increase the cronJob timeout from 5 to 10 minutes to make sure there is enough time for the task to succeed.

- 3dd8720 Increase cacheCleaner cronjob deadline to 10 minutes
- a78e4d3 Refactor cacheCleaner to only compute size once

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3332](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3332)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
