### PR TITLE
Await writing template to temp directory

### DIFF
--- a/app/cacheCleaner.js
+++ b/app/cacheCleaner.js
@@ -5,7 +5,7 @@ const { join } = require('path');
 
 const log = require('./src/components/log')(module.filename);
 
-const RATIO = 0.8; // Best practice is to keep the cache no more than 80% full
+const RATIO = 0.7; // Best practice is to keep the cache no more than 70% full
 
 const osTempDir = realpathSync(tmpdir());
 const cacheDir = (() => {

--- a/app/src/routes/v2/template.js
+++ b/app/src/routes/v2/template.js
@@ -10,7 +10,9 @@ const log = require('../../components/log')(module.filename);
 
 const fileCache = new FileCache();
 
-/** Returns the rendered report from cache */
+/**
+ *  Upload a template to cache
+ */
 templateRouter.post('/', upload, async (req, res) => {
   log.verbose('Template upload');
 
@@ -28,6 +30,9 @@ templateRouter.post('/', upload, async (req, res) => {
   }
 });
 
+/**
+ * Render a document from a template provided in JSON body
+ */
 templateRouter.post('/render', middleware.validateTemplate, async (req, res) => {
   log.verbose('Template upload and render');
 
@@ -52,12 +57,18 @@ templateRouter.post('/render', middleware.validateTemplate, async (req, res) => 
   return await findAndRender(content.hash, req, res);
 });
 
+/**
+ * Render a document from a cached template
+ */
 templateRouter.post('/:uid/render', middleware.validateCarbone, async (req, res) => {
   const hash = req.params.uid;
   log.verbose('Template render', { hash: hash });
   return await findAndRender(hash, req, res);
 });
 
+/**
+ * get a template from cache
+ */
 templateRouter.get('/:uid', async (req, res) => {
   const hash = req.params.uid;
   const download = req.query.download !== undefined;
@@ -66,6 +77,9 @@ templateRouter.get('/:uid', async (req, res) => {
   return getFromCache(hash, hashHeaderName, download, false, res);
 });
 
+/**
+ * delete a template from cache
+ */
 templateRouter.delete('/:uid', async (req, res) => {
   const hash = req.params.uid;
   const download = req.query.download !== undefined;


### PR DESCRIPTION
Attempt to handle a race condition during copying template from temp directory to the file cache

<!-- Provide a general summary of your changes in the Title above -->
# Description

Ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3693

- await the completion of writing template to temp directory before progressing to move the file.
- simplified code to define a temp file name
- added some minor code comments

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
