### PR TITLE
Improve template file handling

### DIFF
--- a/app/src/components/carboneCopyApi.js
+++ b/app/src/components/carboneCopyApi.js
@@ -14,12 +14,12 @@ const carboneCopyApi = {
     carboneRender.carboneSet();
   },
 
-  findAndRender: (hash, req, res) => {
+  findAndRender: async (hash, req, res) => {
     const template = fileCache.find(hash);
     if (!template.success) {
       new Problem(template.errorType, { detail: template.errorMsg }).send(res);
     } else {
-      return carboneCopyApi.renderTemplate(template, req, res);
+      return await carboneCopyApi.renderTemplate(template, req, res);
     }
   },
 

--- a/app/src/components/fileCache.js
+++ b/app/src/components/fileCache.js
@@ -63,14 +63,16 @@ class FileCache {
       if (!fs.existsSync(hashPath)) {
         result.errorType = 404;
         result.errorMsg = `Hash '${hash}' not found.`;
+        log.error(`Hash '${hash}' not found.`, { function: 'fileCache.find', result });
         return result;
       }
       result.hash = hash;
 
       const files = fs.readdirSync(hashPath);
-      if (!files || files.length !== 1) {
+      if (!files || files.length === 0) {
         result.errorType = 404;
         result.errorMsg = 'Hash found; could not read file from cache.';
+        log.error('Hash found. could not read file from cache', { function: 'fileCache.find', result });
         return result;
       } else {
         result.name = files[0];
@@ -121,9 +123,10 @@ class FileCache {
     }
 
     const hashPath = this._getHashPath(result.hash);
-    // if file exists at temp file path
+    // if template exists
     if (fs.existsSync(hashPath)) {
       if (options.overwrite) {
+        // remove template
         fs.removeSync(hashPath);
       } else {
         // Remove temporary file from cache


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
# Description

when a high frequency of requests hit the app,
template files are not managed consistently.
fileCache.find should handle when more than one template is found.


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
