### PR TITLE
GHA: explicitly install oc first

### DIFF
--- a/.github/actions/deploy-to-environment/action.yaml
+++ b/.github/actions/deploy-to-environment/action.yaml
@@ -35,13 +35,19 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Login to OpenShift Cluster
-      uses: redhat-actions/oc-login@v1
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
       with:
-        openshift_server_url: ${{ inputs.openshift_server }}
-        openshift_token: ${{ inputs.openshift_token }}
-        insecure_skip_tls_verify: true
-        namespace: ${{ inputs.namespace_prefix }}-${{ inputs.namespace_environment }}
+        oc: "4"
+
+    - name: Login to OpenShift and select project
+      shell: bash
+      run: |
+        # OC Login
+        OC_TEMP_TOKEN=$(curl -k -X POST ${{ inputs.openshift_server }}/api/v1/namespaces/${{ inputs.namespace_prefix }}-${{ inputs.namespace_environment }}/serviceaccounts/pipeline/token --header "Authorization: Bearer ${{ inputs.openshift_token }}" -d '{"spec": {"expirationSeconds": 600}}' -H 'Content-Type: application/json; charset=utf-8' | jq -r '.status.token' )
+        oc login --token=$OC_TEMP_TOKEN --server=${{ inputs.openshift_server }}
+        # move to project context
+        oc project ${{ inputs.namespace_prefix }}-${{ inputs.namespace_environment }}
 
     - name: Helm Deploy
       shell: bash

--- a/.github/workflows/on-pr-closed.yaml
+++ b/.github/workflows/on-pr-closed.yaml
@@ -28,13 +28,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Login to OpenShift Cluster
-      uses: redhat-actions/oc-login@v1
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
       with:
-        openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
-        openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-        insecure_skip_tls_verify: true
-        namespace: ${{ env.NAMESPACE_PREFIX }}-dev
+        oc: "4"
+    - name: Login to OpenShift and select project
+      shell: bash
+      run: |
+        # OC Login
+        OC_TEMP_TOKEN=$(curl -k -X POST ${{ secrets.OPENSHIFT_SERVER }}/api/v1/namespaces/${{ env.NAMESPACE_PREFIX }}-dev/serviceaccounts/pipeline/token --header "Authorization: Bearer ${{ secrets.OPENSHIFT_TOKEN }}" -d '{"spec": {"expirationSeconds": 600}}' -H 'Content-Type: application/json; charset=utf-8' | jq -r '.status.token' )
+        oc login --token=$OC_TEMP_TOKEN --server=${{ secrets.OPENSHIFT_SERVER }}
+        # move to project context
+        oc project ${{ env.NAMESPACE_PREFIX }}-dev
     - name: Remove PR Deployment
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This adds an additional GitHub Actions step for installing `oc`.

<!-- Why is this change required? What problem does it solve? -->
The `ubuntu-latest` GitHub Actions image no longer includes `oc` out of the box, so it must now be explicitly installed.

*More info:* https://github.com/actions/runner-images/issues/10636

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3816

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

N/A