### PR TITLE
Enable PDF/UA compliance in LibreOffice registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN wget https://www2.gov.bc.ca/assets/gov/british-columbians-our-governments/se
     rm -rf ./BcSansFont_Print && \
     fc-cache -f
 
+# enable PDF/UA compliance in LibreOffice registry
+RUN sed -i \
+  's|<prop oor:name="PDFUACompliance" oor:type="xs:boolean" oor:nillable="false"><value>false</value></prop>|<prop oor:name="PDFUACompliance" oor:type="xs:boolean" oor:nillable="false"><value>true</value></prop>|' \
+  /usr/lib/libreoffice/share/registry/main.xcd
+
 # NPM Permission Fix
 RUN mkdir -p /.npm
 RUN chown -R 1001:0 /.npm


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Modify the LibreOffice registry so that PDF/UA compliance is enabled on PDFs generated by CDOGS. 

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [X] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
