### PR TITLE
fix: upgrade js-yaml to 4.3.1, 3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,7 +20,7 @@
         "express-winston": "^4.2.0",
         "fs-extra": "^11.2.0",
         "helmet": "^7.1.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "jsonwebtoken": "^9.0.2",
         "lockfile": "^1.0.4",
         "mime-types": "^2.1.35",
@@ -4014,9 +4014,20 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -8987,9 +8998,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,7 @@
     "express-winston": "^4.2.0",
     "fs-extra": "^11.2.0",
     "helmet": "^7.1.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.1",
     "jsonwebtoken": "^9.0.2",
     "lockfile": "^1.0.4",
     "mime-types": "^2.1.35",


### PR DESCRIPTION
## Summary
Upgrade js-yaml from 4.1.0 to 4.3.1, 3.15.1 to fix GHSA-5p4m-2wfm-xmqj.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-5p4m-2wfm-xmqj |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-5p4m-2wfm-xmqj` |
| **File** | `app/package-lock.json` (dependency: `js-yaml`) |
| **Assessment** | Defensive hardening |

**Description**: JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported

## Changes
- `app/package.json`
- `app/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
